### PR TITLE
Ignore schema.rb anywhere

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    arcadia_cops (1.0.4)
+    arcadia_cops (1.0.5)
       rubocop (= 0.49.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.3.0)
-    parallel (1.11.2)
+    parallel (1.12.0)
     parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)

--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'arcadia_cops'
-  s.version = '1.0.4'
+  s.version = '1.0.5'
   s.summary = 'Arcadia Power Style Cops'
   s.description = 'Contains enabled rubocops for arcadia power ruby repos.'
   s.authors = %w(justin)

--- a/config/config.yml
+++ b/config/config.yml
@@ -13,7 +13,7 @@ AllCops:
     - '**/Guardfile'
   Exclude:
     - 'vendor/**/*'
-    - '**/db/schema.rb'
+    - '**/schema.rb'
   # Default formatter will be used if no -f/--format option is given.
   DefaultFormatter: progress
   # Cop names are not displayed in offense messages by default. Change behavior


### PR DESCRIPTION
Ignores the secondbase schema.rb file as well. `schema.rb` should be a
file name we use anywhere in our codebase, so this should cover all
engines, dummy apps, etc. as well

http://rubocop.readthedocs.io/en/latest/configuration/#includingexcluding-files