### PR TITLE
Enables the ConvertTry attr of SafeNavigation

### DIFF
--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'arcadia_cops'
-  s.version = '3.1.0'
+  s.version = '3.2.0'
   s.summary = 'Arcadia Power Style Cops'
   s.description = 'Contains enabled rubocops for arcadia power ruby repos.'
   s.authors = %w(justin)

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -282,6 +282,7 @@ Rails/Output:
 
 Rails/SafeNavigation:
   Description: "Use Ruby's safe navigation operator (`&.`) instead of `try!`"
+  ConvertTry: true
 
 Rails/Date:
   Description: >-


### PR DESCRIPTION
Prior to this change, only `.try!` would be caught, not `.try`.