### PR TITLE
turn on abc complexity

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -245,6 +245,14 @@ Style/Encoding:
 
 ######### METRICS #########
 
+Metrics/AbcSize:
+  Description: >-
+                 A calculated magnitude based on number of assignments,
+                 branches, and conditions.
+  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
+  Enabled: true
+  Severity: refactor
+
 ######### PERFORMANCE #########
 
 Performance/Size:


### PR DESCRIPTION
How to run this.

In your gemfile, change this:
`gem 'arcadia_cops', '~> 1.0'`
to this:
`gem 'arcadia_cops', :github => 'ArcadiaPower/rubocop', :branch => 'chore/abc_complexity'`

The run rubocop as normal. Watch the show.
