### PR TITLE
Added 6 layout cops

### DIFF
--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'arcadia_cops'
-  s.version = '1.0.7'
+  s.version = '2.0.0'
   s.summary = 'Arcadia Power Style Cops'
   s.description = 'Contains enabled rubocops for arcadia power ruby repos.'
   s.authors = %w(justin)

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -552,3 +552,24 @@ Lint/UselessSetterCall:
 
 Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
+
+Layout/CommentIndentation:
+  Description: Indentation of comments.
+
+Layout/EmptyLinesAroundArguments:
+  Description: Keeps track of empty lines around method arguments.
+
+Layout/EmptyLinesAroundBeginBody:
+  Description: Keeps track of empty lines around begin-end bodies.
+  StyleGuide: "#empty-lines-around-bodies"
+
+Layout/FirstHashElementLineBreak:
+  Description: Checks for a line break before the first element in a multi-line hash.
+
+Layout/FirstArrayElementLineBreak:
+  Description: Checks for a line break before the first element in a multi-line array.
+
+Layout/IndentationConsistency:
+  Description: Keep indentation straight.
+  StyleGuide: "#spaces-indentation"
+  EnforcedStyle: rails


### PR DESCRIPTION
In the spirit of ruby style guides I was taking a look at our cops for some more auto enforcement.

`bundle exec rubocop --show-cops` and then ctrl+f for "Enabled: false"

Here are 6 i added that had minimal violations in 🐧. Putting in a PR on that side as well to update.

Also i bumped version to 2.0, i guess we should just always use major versions for cop updates as they are likely to break our apps and require changes.