### PR TITLE
Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 3.4.0 / 2019-2-4
+
+* Bump rubocop to [0.63.1](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0631-2019-01-22)
+* Update Rspec rubocop to [1.32.0](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md#1320-2019-01-27)
+* Import batch of rules from penguin
+
+
 ## 1.0.6 / 2018-3-12
 
 * Bump Rubocop to [0.53.9](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0530-2018-03-05)
 * Add Lambda style cop
-
 
 ## 1.0.3 / 2017-7-19
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,33 @@
 PATH
   remote: .
   specs:
-    arcadia_cops (3.3.0)
-      rubocop (= 0.59.0)
-      rubocop-rspec (= 1.29)
+    arcadia_cops (3.4.0)
+      rubocop (= 0.63.1)
+      rubocop-rspec (= 1.32)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    jaro_winkler (1.5.1)
-    parallel (1.12.1)
-    parser (2.5.3.0)
+    jaro_winkler (1.5.2)
+    parallel (1.13.0)
+    parser (2.6.0.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
-    rake (12.0.0)
-    rubocop (0.59.0)
+    rake (12.3.2)
+    rubocop (0.63.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.29.0)
-      rubocop (>= 0.58.0)
+      unicode-display_width (~> 1.4.0)
+    rubocop-rspec (1.32.0)
+      rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
 
 PLATFORMS
   ruby
@@ -38,4 +38,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'arcadia_cops'
-  s.version = '3.3.0'
+  s.version = '3.4.0'
   s.summary = 'Arcadia Power Style Cops'
   s.description = 'Contains enabled rubocops for arcadia power ruby repos.'
   s.authors = %w(justin)
@@ -11,8 +11,8 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/ArcadiaPower/rubocop/'
   s.license = 'MIT'
 
-  s.add_dependency 'rubocop', '0.59.0'
-  s.add_dependency 'rubocop-rspec', '1.29'
+  s.add_dependency 'rubocop', '0.63.1'
+  s.add_dependency 'rubocop-rspec', '1.32'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -679,3 +679,27 @@ Layout/SpaceInsideStringInterpolation:
 Style/ReturnNil:
   Description: Use return instead of return nil.
   EnforcedStyle: return
+
+Style/Dir:
+  Description: Use the `__dir__` method to retrieve the canonicalized absolute path
+    to the current file.
+  Enabled: true
+
+Style/ExpandPathArguments:
+  Description: Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`.
+  Enabled: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Style/RedundantFreeze:
+  Enabled: true
+
+RSpec/ScatteredSetup:
+  Enabled: true
+
+RSpec/ScatteredLet:
+  Enabled: true
+
+RSpec/Focus:
+  Enabled: true


### PR DESCRIPTION
See changelog

This was particularly motivated by wanting to use the new rescue format within block introduced in rails 5 without throwing a rubocop error.