### PR TITLE
update target ruby version

### DIFF
--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'arcadia_cops'
-  s.version = '3.4.0'
+  s.version = '3.5.0'
   s.summary = 'Arcadia Power Style Cops'
   s.description = 'Contains enabled rubocops for arcadia power ruby repos.'
   s.authors = %w(justin)

--- a/config/config.yml
+++ b/config/config.yml
@@ -70,7 +70,7 @@ AllCops:
   # If a value is specified for TargetRubyVersion then it is used.
   # Else if .ruby-version exists and it contains an MRI version it is used.
   # Otherwise we fallback to the oldest officially supported Ruby version (2.1).
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 Rails:
   Enabled: false


### PR DESCRIPTION
moving to 2.5 since both penguin and macaw are on 2.5 and this allows some new syntax to not be flagged by rubocop.