### PR TITLE
Removing duplicate directive.

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -106,10 +106,6 @@ Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in argument lists.'
   StyleGuide: '#no-trailing-params-comma'
 
-Style/TrailingCommaInArguments:
-  Description: 'Checks for trailing comma in argument lists.'
-  StyleGuide: '#no-trailing-params-comma'
-
 Style/TrailingCommaInArrayLiteral:
   Description: 'Checks for trailing comma in array literals.'
   StyleGuide: '#no-trailing-array-commas'


### PR DESCRIPTION
Someone **REALLY** didn't want a trailing comma in arguments!