### PR TITLE
Remove Target Ruby Version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    arcadia_cops (3.5.2)
+    arcadia_cops (3.5.3)
       rubocop (= 0.63.1)
       rubocop-rspec (= 1.32)
 
@@ -11,7 +11,7 @@ GEM
     ast (2.4.0)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)

--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'arcadia_cops'
-  s.version = '3.5.2'
+  s.version = '3.5.3'
   s.summary = 'Arcadia Power Style Cops'
   s.description = 'Contains enabled rubocops for arcadia power ruby repos.'
   s.authors = %w(justin)

--- a/config/config.yml
+++ b/config/config.yml
@@ -70,7 +70,7 @@ AllCops:
   # If a value is specified for TargetRubyVersion then it is used.
   # Else if .ruby-version exists and it contains an MRI version it is used.
   # Otherwise we fallback to the oldest officially supported Ruby version (2.1).
-  TargetRubyVersion: 2.5
+  # TargetRubyVersion: 2.5 # SPECIFY IN PROJECT .ruby-version file
 
 Rails:
   Enabled: false


### PR DESCRIPTION
Projects that use this gem can either specify the target Ruby version in the `.ruby-version` file, or by adding this config back in their own `.rubocop.yml` file. It doesn't really make sense to make the gem specify a version.