### PR TITLE
Remove lint rule that was retired in the recent upgrade

### DIFF
--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'arcadia_cops'
-  s.version = '4.0.1'
+  s.version = '4.0.2'
   s.summary = 'Arcadia Power Style Cops'
   s.description = 'Contains enabled rubocops for arcadia power ruby repos.'
   s.authors = %w(engineering)

--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/ArcadiaPower/arcadia_cops/'
   s.license = 'MIT'
 
-  s.add_dependency 'rubocop', '~> 1.26'
+  s.add_dependency 'rubocop', '~> 1.29.1'
   s.add_dependency 'rubocop-rails', '~> 2.9'
   s.add_dependency 'rubocop-rspec', '~> 2.2'
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -529,9 +529,6 @@ Lint/UselessAssignment:
 Lint/BinaryOperatorWithIdenticalOperands:
   Description: 'Checks for comparison of something with itself.'
 
-Lint/UselessElseWithoutRescue:
-  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
-
 Lint/UselessSetterCall:
   Description: 'Checks for useless setter call to a local variable.'
 


### PR DESCRIPTION
Release: 4.0.2

Per the [changelog](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#L92), this rule was retired during the last upgrade.