### PR TITLE
Add SimpleUnless and SimpleModifierConditional cops

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,55 +1,67 @@
 PATH
   remote: .
   specs:
-    arcadia_cops (4.0.1)
-      rubocop (~> 1.26)
+    arcadia_cops (4.0.3)
+      rubocop (~> 1.29.1)
       rubocop-rails (~> 2.9)
       rubocop-rspec (~> 2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.5)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
+    diff-lcs (1.5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     minitest (5.15.0)
-    parallel (1.21.0)
-    parser (3.1.1.0)
+    parallel (1.22.1)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.2.1)
+    regexp_parser (2.5.0)
     rexml (3.2.5)
-    rubocop (1.26.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    rubocop (1.29.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.16.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.17.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.16.0)
+    rubocop-ast (1.18.0)
       parser (>= 3.1.1.0)
-    rubocop-rails (2.13.2)
+    rubocop-rails (2.15.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
-    rubocop-rspec (2.9.0)
+    rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
-    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby
@@ -58,6 +70,7 @@ DEPENDENCIES
   arcadia_cops!
   bundler (> 2.0.2)
   rake
+  rspec
 
 BUNDLED WITH
    2.2.28

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Add a new cop to the `enabled.yml`, bump the version, and put in a PR for review
 
 To see all cops including those that aren't enabled run `bundle exec rubocop --show-cops`.
 
+WHen developing custom cops, make sure to add specs and run run `bundle exec rspec` before releasing.
+
 ## Release
 
 Ensure you have bumped the version and run `rake release` to release to rubygems.org.

--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -2,12 +2,16 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'arcadia_cops'
-  s.version = '4.0.2'
-  s.summary = 'Arcadia Power Style Cops'
-  s.description = 'Contains enabled rubocops for arcadia power ruby repos.'
+  s.version = '4.0.3'
+  s.summary = 'Arcadia Style Cops'
+  s.description = 'Contains enabled rubocops for Arcadia ruby repos.'
   s.authors = %w(engineering)
   s.email = %w(engineering@arcadia.com)
-  s.files = Dir['README.md', 'config/*.yml']
+  s.files = Dir[
+    'README.md',
+    'config/*.yml',
+    'lib/**/*'
+  ]
   s.homepage = 'https://github.com/ArcadiaPower/arcadia_cops/'
   s.license = 'MIT'
 
@@ -16,5 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rubocop-rspec', '~> 2.2'
 
   s.add_development_dependency 'bundler', '> 2.0.2'
+  s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
 end

--- a/config/config.yml
+++ b/config/config.yml
@@ -4,6 +4,7 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - ../lib/arcadia_cops.rb
 
 # Common configuration.
 AllCops:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -687,3 +687,9 @@ Style/Not:
 
 Style/NegatedUnless:
   Enabled: true
+
+ArcadiaCops/SimpleModifierConditional:
+  Enabled: true
+
+ArcadiaCops/SimpleUnless:
+  Enabled: true

--- a/lib/arcadia_cops.rb
+++ b/lib/arcadia_cops.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+Dir.glob(File.expand_path('arcadia_cops/*.rb', File.dirname(__FILE__))).map(&method(:require))

--- a/lib/arcadia_cops/simple_modifier_conditional.rb
+++ b/lib/arcadia_cops/simple_modifier_conditional.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ArcadiaCops
+  # Cop to tackle prevent more complicated modifier if/unless statements
+  # https://github.com/airbnb/ruby/blob/12435e8136d2adf710de999bc0f6bef01215df2c/rubocop-airbnb/lib/rubocop/cop/airbnb/simple_modifier_conditional.rb
+  class SimpleModifierConditional < RuboCop::Cop::Cop
+    MSG = 'Modifier if/unless usage is okay when the body is simple, ' \
+      'the condition is simple, and the whole thing fits on one line. ' \
+      'Otherwise, avoid modifier if/unless.'.freeze
+
+    def_node_matcher :multiple_conditionals?, '(if ({and or :^} ...) ...)'
+
+    def on_if(node)
+      return unless node.modifier_form?
+
+      if multiple_conditionals?(node) || node.multiline?
+        add_offense(node)
+      end
+    end
+  end
+end

--- a/lib/arcadia_cops/simple_unless.rb
+++ b/lib/arcadia_cops/simple_unless.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ArcadiaCops
+  # Cop to tackle prevent unless statements with multiple conditions
+  # https://github.com/airbnb/ruby/blob/12435e8136d2adf710de999bc0f6bef01215df2c/rubocop-airbnb/lib/rubocop/cop/airbnb/simple_unless.rb
+  class SimpleUnless < RuboCop::Cop::Cop
+    MSG = 'Unless usage is okay when there is only one conditional'.freeze
+
+    def_node_matcher :multiple_conditionals?, '(if ({and or :^} ...) ...)'
+
+    def on_if(node)
+      return unless node.unless?
+
+      add_offense(node) if multiple_conditionals?(node)
+    end
+  end
+end

--- a/spec/lib/arcadia_cops/simple_modifier_conditional_spec.rb
+++ b/spec/lib/arcadia_cops/simple_modifier_conditional_spec.rb
@@ -1,0 +1,123 @@
+# Originally from https://github.com/airbnb/ruby/blob/12435e8136d2adf710de999bc0f6bef01215df2c/rubocop-airbnb/spec/rubocop/cop/airbnb/simple_modifier_conditional_spec.rb
+describe ArcadiaCops::SimpleModifierConditional do
+  subject(:cop) { described_class.new }
+
+  context 'multiple conditionals' do
+    it 'rejects with modifier if with multiple conditionals' do
+      source = [
+        'return true if some_method == 0 || another_method',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'rejects with modifier unless with multiple conditionals' do
+      source = [
+        'return true unless true && false',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'allows with modifier if operator conditional' do
+      source = [
+        'return true if some_method == 0',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'allows with modifier if with single conditional' do
+      source = [
+        'return true if some_method == 0',
+        'return true if another_method',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'allows with modifier if and unless with single conditional ' do
+      source = [
+        'return true if some_method',
+        'return true unless another_method > 5',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'allows multiple conditionals in block form' do
+      source = [
+        'if some_method == 0 && another_method > 5 || true || false',
+        ' return true',
+        'end',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'multiple lines' do
+    it 'rejects modifier conditionals that span multiple lines' do
+      source = [
+        'return true if true ||',
+        '               false',
+        'return true unless true ||',
+        '                   false',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses.size).to eq(2)
+    end
+
+    it 'rejects with modifier if with method that spans multiple lines' do
+      source = [
+        'return true if some_method(param1,',
+        '                           param2,',
+        '                           param3)',
+        'return true unless some_method(param1,',
+        '                               param2,',
+        '                               param3)',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses.size).to eq(2)
+    end
+
+    it 'rejects inline if/unless after a multiline statement' do
+      source = [
+        'return some_method(',
+        '  param1,',
+        '  param2,',
+        '  param3',
+        ') if another_method == 0',
+        'return some_method(',
+        '  param1,',
+        '  param2,',
+        '  param3',
+        ') unless another_method == 0',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses.size).to eq(2)
+    end
+
+    it 'allows multline conditionals in block form' do
+      source = [
+        'if some_method(param1,',
+        '               param2,',
+        '               parma3)',
+        ' return true',
+        'end',
+      ].join("\n")
+
+      inspect_source(source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+end

--- a/spec/lib/arcadia_cops/simple_unless_spec.rb
+++ b/spec/lib/arcadia_cops/simple_unless_spec.rb
@@ -1,0 +1,37 @@
+# Originally from https://github.com/airbnb/ruby/blob/12435e8136d2adf710de999bc0f6bef01215df2c/rubocop-airbnb/spec/rubocop/cop/airbnb/simple_unless_spec.rb
+describe ArcadiaCops::SimpleUnless do
+  subject(:cop) { described_class.new }
+
+  it 'rejects unless with multiple conditionals' do
+    source = [
+      'unless boolean_condition || another_method',
+      '  return true',
+      'end',
+    ].join("\n")
+
+    inspect_source(source)
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'allows if with multiple conditionals' do
+    source = [
+      'if boolean_condition || another_method',
+      '  return true',
+      'end',
+    ].join("\n")
+
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'allows with modifier if operator conditional' do
+    source = [
+      'unless boolean_condition',
+      '  return true',
+      'end',
+    ].join("\n")
+
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require File.expand_path('lib/arcadia_cops')
+require 'rubocop/rspec/support'
+
+RSpec.configure do |config|
+  config.order = :random
+
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect # Disable `should`
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect # Disable `should_receive` and `stub`
+  end
+end


### PR DESCRIPTION
Adds cops to flag two Ruby style guide violations I see frequently in EP PRs:
- [Avoid unless with multiple conditions](https://github.com/ArcadiaPower/anoctua/blob/master/docs/style_guides/ruby.md#unless-with-multiple-conditions)
- [Modifier if/unless usage is okay when the body is simple, the condition is simple, and the whole thing fits on one line. Otherwise, avoid modifier if/unless](https://github.com/ArcadiaPower/anoctua/blob/master/docs/style_guides/ruby.md#only-simple-if-unless)

Like our Ruby style guide, these cops are repurposed from open source contributions from Airbnb. Unfortunately, their public gem that includes cops to back their style guide rules is [pinned to Rubocop v0.93](https://github.com/airbnb/ruby/blob/12435e8136d2adf710de999bc0f6bef01215df2c/rubocop-airbnb/rubocop-airbnb.gemspec#L28), which is about 1.5 years behind Rubocop's current version.

So instead of including `rubocop-airbnb` directly and re-using their cops, this PR will selectively vendor the cops we are interested in adding, so that we can keep our Rubocop dependency up to date.

Tested locally by changing EP's `Gemfile` to use ` gem 'arcadia_cops', '~> 4.0', path: "../arcadia_cops"` and running `bin/rubocop`. As expected, it flagged many instances we don't conform to the style guide.