### PR TITLE
update config and fix deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.sublime-project
 *.sublime-workspace
+.idea
 
 # Ignore bundler config.
 /.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    arcadia_cops (4.0.4)
+    arcadia_cops (5.0.1)
       rubocop (~> 1.29)
       rubocop-rails (~> 2.9)
       rubocop-rspec (~> 2.2)
@@ -38,13 +38,13 @@ GEM
     logger (1.7.0)
     minitest (5.25.5)
     mutex_m (0.3.0)
-    parallel (1.26.3)
-    parser (3.3.7.4)
+    parallel (1.27.0)
+    parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
     racc (1.8.1)
-    rack (3.1.12)
+    rack (3.1.13)
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.10.0)
@@ -72,7 +72,7 @@ GEM
       rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.44.0)
+    rubocop-ast (1.44.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-capybara (2.22.1)
@@ -112,4 +112,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.2.28
+   2.2.33

--- a/arcadia_cops.gemspec
+++ b/arcadia_cops.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = 'arcadia_cops'
-  s.version = '5.0.0'
+  s.version = '5.0.1'
   s.summary = 'Arcadia Style Cops'
   s.description = 'Contains enabled rubocops for Arcadia ruby repos.'
   s.authors = %w(engineering)

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,8 +1,10 @@
 # This is the default configuration file. Enabling and disabling is configured
 # in separate files. This file adds all other parameters apart from Enabled.
 
-require:
+plugins:
   - rubocop-rails
+
+require:
   - rubocop-rspec
   - ../lib/arcadia_cops.rb
 

--- a/lib/arcadia_cops/simple_modifier_conditional.rb
+++ b/lib/arcadia_cops/simple_modifier_conditional.rb
@@ -3,7 +3,7 @@
 module ArcadiaCops
   # Cop to tackle prevent more complicated modifier if/unless statements
   # https://github.com/airbnb/ruby/blob/12435e8136d2adf710de999bc0f6bef01215df2c/rubocop-airbnb/lib/rubocop/cop/airbnb/simple_modifier_conditional.rb
-  class SimpleModifierConditional < RuboCop::Cop::Cop
+  class SimpleModifierConditional < RuboCop::Cop::Base
     MSG = 'Modifier if/unless usage is okay when the body is simple, ' \
       'the condition is simple, and the whole thing fits on one line. ' \
       'Otherwise, avoid modifier if/unless.'.freeze

--- a/lib/arcadia_cops/simple_unless.rb
+++ b/lib/arcadia_cops/simple_unless.rb
@@ -3,7 +3,7 @@
 module ArcadiaCops
   # Cop to tackle prevent unless statements with multiple conditions
   # https://github.com/airbnb/ruby/blob/12435e8136d2adf710de999bc0f6bef01215df2c/rubocop-airbnb/lib/rubocop/cop/airbnb/simple_unless.rb
-  class SimpleUnless < RuboCop::Cop::Cop
+  class SimpleUnless < RuboCop::Cop::Base
     MSG = 'Unless usage is okay when there is only one conditional'.freeze
 
     def_node_matcher :multiple_conditionals?, '(if ({and or :^} ...) ...)'

--- a/spec/lib/arcadia_cops/simple_modifier_conditional_spec.rb
+++ b/spec/lib/arcadia_cops/simple_modifier_conditional_spec.rb
@@ -1,123 +1,101 @@
 # Originally from https://github.com/airbnb/ruby/blob/12435e8136d2adf710de999bc0f6bef01215df2c/rubocop-airbnb/spec/rubocop/cop/airbnb/simple_modifier_conditional_spec.rb
-describe ArcadiaCops::SimpleModifierConditional do
-  subject(:cop) { described_class.new }
+RSpec.describe ArcadiaCops::SimpleModifierConditional, :config do
+  let(:config) { RuboCop::Config.new }
 
   context 'multiple conditionals' do
     it 'rejects with modifier if with multiple conditionals' do
-      source = [
-        'return true if some_method == 0 || another_method',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<~RUBY)
+        return true if some_method == 0 || another_method
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ArcadiaCops/SimpleModifierConditional: Modifier if/unless usage is okay when the body is simple, the condition is simple, and the whole thing fits on one line. Otherwise, avoid modifier if/unless.
+      RUBY
     end
 
     it 'rejects with modifier unless with multiple conditionals' do
-      source = [
-        'return true unless true && false',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<~RUBY)
+        return true unless true && false
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ArcadiaCops/SimpleModifierConditional: Modifier if/unless usage is okay when the body is simple, the condition is simple, and the whole thing fits on one line. Otherwise, avoid modifier if/unless.
+      RUBY
     end
 
     it 'allows with modifier if operator conditional' do
-      source = [
-        'return true if some_method == 0',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<~RUBY)
+        return true if some_method == 0
+      RUBY
     end
 
     it 'allows with modifier if with single conditional' do
-      source = [
-        'return true if some_method == 0',
-        'return true if another_method',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<~RUBY)
+        return true if some_method == 0
+        return true if another_method
+      RUBY
     end
 
     it 'allows with modifier if and unless with single conditional ' do
-      source = [
-        'return true if some_method',
-        'return true unless another_method > 5',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<~RUBY)
+        return true if some_method
+        return true unless another_method > 5
+      RUBY
     end
 
     it 'allows multiple conditionals in block form' do
-      source = [
-        'if some_method == 0 && another_method > 5 || true || false',
-        ' return true',
-        'end',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<~RUBY)
+        if some_method == 0 && another_method > 5 || true || false
+         return true
+        end
+      RUBY
     end
   end
 
   context 'multiple lines' do
     it 'rejects modifier conditionals that span multiple lines' do
-      source = [
-        'return true if true ||',
-        '               false',
-        'return true unless true ||',
-        '                   false',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(2)
+      expect_offense(<<~RUBY)
+        return true if true ||
+        ^^^^^^^^^^^^^^^^^^^^^^ ArcadiaCops/SimpleModifierConditional: Modifier if/unless usage is okay when the body is simple, the condition is simple, and the whole thing fits on one line. Otherwise, avoid modifier if/unless.
+                       false
+        return true unless true ||
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ ArcadiaCops/SimpleModifierConditional: Modifier if/unless usage is okay when the body is simple, the condition is simple, and the whole thing fits on one line. Otherwise, avoid modifier if/unless.
+                           false
+      RUBY
     end
 
     it 'rejects with modifier if with method that spans multiple lines' do
-      source = [
-        'return true if some_method(param1,',
-        '                           param2,',
-        '                           param3)',
-        'return true unless some_method(param1,',
-        '                               param2,',
-        '                               param3)',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(2)
+      expect_offense(<<~RUBY)
+        return true if some_method(param1,
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ArcadiaCops/SimpleModifierConditional: Modifier if/unless usage is okay when the body is simple, the condition is simple, and the whole thing fits on one line. Otherwise, avoid modifier if/unless.
+                                   param2,
+                                   param3)
+        return true unless some_method(param1,
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ArcadiaCops/SimpleModifierConditional: Modifier if/unless usage is okay when the body is simple, the condition is simple, and the whole thing fits on one line. Otherwise, avoid modifier if/unless.
+                                       param2,
+                                       param3)
+      RUBY
     end
 
     it 'rejects inline if/unless after a multiline statement' do
-      source = [
-        'return some_method(',
-        '  param1,',
-        '  param2,',
-        '  param3',
-        ') if another_method == 0',
-        'return some_method(',
-        '  param1,',
-        '  param2,',
-        '  param3',
-        ') unless another_method == 0',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(2)
+      expect_offense(<<~RUBY)
+        return some_method(
+        ^^^^^^^^^^^^^^^^^^^ ArcadiaCops/SimpleModifierConditional: Modifier if/unless usage is okay when the body is simple, the condition is simple, and the whole thing fits on one line. Otherwise, avoid modifier if/unless.
+          param1,
+          param2,
+          param3
+        ) if another_method == 0
+        return some_method(
+        ^^^^^^^^^^^^^^^^^^^ ArcadiaCops/SimpleModifierConditional: Modifier if/unless usage is okay when the body is simple, the condition is simple, and the whole thing fits on one line. Otherwise, avoid modifier if/unless.
+          param1,
+          param2,
+          param3
+        ) unless another_method == 0
+      RUBY
     end
 
     it 'allows multline conditionals in block form' do
-      source = [
-        'if some_method(param1,',
-        '               param2,',
-        '               parma3)',
-        ' return true',
-        'end',
-      ].join("\n")
-
-      inspect_source(source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<~RUBY)
+        if some_method(param1,
+                       param2,
+                       parma3)
+         return true
+        end
+      RUBY
     end
   end
 end

--- a/spec/lib/arcadia_cops/simple_unless_spec.rb
+++ b/spec/lib/arcadia_cops/simple_unless_spec.rb
@@ -1,37 +1,29 @@
 # Originally from https://github.com/airbnb/ruby/blob/12435e8136d2adf710de999bc0f6bef01215df2c/rubocop-airbnb/spec/rubocop/cop/airbnb/simple_unless_spec.rb
-describe ArcadiaCops::SimpleUnless do
-  subject(:cop) { described_class.new }
+RSpec.describe ArcadiaCops::SimpleUnless, :config do
+  let(:config) { RuboCop::Config.new }
 
   it 'rejects unless with multiple conditionals' do
-    source = [
-      'unless boolean_condition || another_method',
-      '  return true',
-      'end',
-    ].join("\n")
-
-    inspect_source(source)
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<~RUBY)
+      unless boolean_condition || another_method
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ArcadiaCops/SimpleUnless: Unless usage is okay when there is only one conditional
+        return true
+      end
+    RUBY
   end
 
   it 'allows if with multiple conditionals' do
-    source = [
-      'if boolean_condition || another_method',
-      '  return true',
-      'end',
-    ].join("\n")
-
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<~RUBY)
+      if boolean_condition || another_method
+        return true
+      end
+    RUBY
   end
 
   it 'allows with modifier if operator conditional' do
-    source = [
-      'unless boolean_condition',
-      '  return true',
-      'end',
-    ].join("\n")
-
-    inspect_source(source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<~RUBY)
+      unless boolean_condition
+        return true
+      end
+    RUBY
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,14 @@
 require File.expand_path('lib/arcadia_cops')
+require 'rubocop'
 require 'rubocop/rspec/support'
 
 RSpec.configure do |config|
+  config.include RuboCop::RSpec::ExpectOffense
+  # This is needed for RuboCop::Cop::Base in newer RuboCop versions
+  config.define_derived_metadata(file_path: Regexp.new('spec/lib/arcadia_cops')) do |metadata|
+    metadata[:config] = true
+  end
+  
   config.order = :random
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
follow-up to https://github.com/ArcadiaPower/arcadia_cops/pull/38

## What
- fix deprecations:
    - migrate to plugins: https://docs.rubocop.org/rubocop/1.75/plugin_migration_guide.html
    - migrate `RuboCop::Cop::Cop` -> `RuboCop::Cop::Base` https://github.com/rubocop/rubocop/pull/13253
- update specs

## Why
deprecation warnings in EP: https://github.com/ArcadiaPower/arcadia-power/pull/25169

```
rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /Users/iiwo/.rvm/gems/ruby-3.1.6/bundler/gems/arcadia_cops-9645efd83f10/config/config.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

/Users/iiwo/.rvm/gems/ruby-3.1.6/bundler/gems/arcadia_cops-9645efd83f10/lib/arcadia_cops/simple_modifier_conditional.rb:6: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.

/Users/iiwo/.rvm/gems/ruby-3.1.6/bundler/gems/arcadia_cops-9645efd83f10/lib/arcadia_cops/simple_unless.rb:6: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.
```